### PR TITLE
Add local config volumn to docker compose for local dev with gcp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - .:/app
       - /app/tests/__pycache__/
+      - $HOME/.config:/root/.config
 
   flexvalue:
     image: flexvalue_shell
@@ -18,6 +19,7 @@ services:
     volumes:
       - .:/app
       - /app/tests/__pycache__/
+      - $HOME/.config:/root/.config
 
   docs:
     image: flexvalue_shell
@@ -34,6 +36,7 @@ services:
     volumes:
       - .:/app
       - /app/tests/__pycache__/
+      - $HOME/.config:/root/.config
 
   jupyter:
     image: flexvalue_shell


### PR DESCRIPTION
Minor update to docker compose, allowing users to use bigquery locally with GCP creds.